### PR TITLE
Add ::serde_dhall::StaticType derive to dhall structs.

### DIFF
--- a/src/type_gen.rs
+++ b/src/type_gen.rs
@@ -177,7 +177,7 @@ impl<'a> TypeGen<'a> {
         let generic = if info.is_open_generic() { quote!(<#generic_parameter>) } else { TokenStream::new() };
         let impl_tokens = self.tokenize_struct_impl(context_ident, ident, info, r)?;
         Ok(quote!(
-        #[derive(Debug, Clone, Eq, PartialEq, Hash, ::serde::Serialize, ::serde::Deserialize)]
+        #[derive(Debug, Clone, Eq, PartialEq, Hash, ::serde::Serialize, ::serde::Deserialize, ::serde_dhall::StaticType)]
         pub struct #ident #generic {
             #tokens
         }


### PR DESCRIPTION
Currently, if struct types are added as variants to enums, the compiler complains that they don't implement StaticType. Adding derive(::serde_dhall::StaticType) on generated structs fixes this issue.